### PR TITLE
Shader: changed rvec X and Y ranges from 0..1 to -1..1

### DIFF
--- a/assets/shaders/Standard.psh
+++ b/assets/shaders/Standard.psh
@@ -105,7 +105,7 @@ float shadow(vec4 lightSpace_position) {
 }
 
 float occlusion(vec3 N) {
-	vec3 rvec = vec3(hash22(gl_FragCoord.xy), 0.0);
+	vec3 rvec = vec3(hash22(gl_FragCoord.xy) * 2.0 - 1.0, 0.0);
 	vec3 tangent = normalize(rvec - N * dot(rvec, N));
 	vec3 bitangent = cross(N, tangent);
 	mat3 tbn = mat3(tangent, bitangent, N);


### PR DESCRIPTION
having the wrong range of values for rvec caused the sampling for SSAO to be biased in certain directions. By fixing this we get better results for the same number of samples.